### PR TITLE
ci(coverage): add cross-module JaCoCo aggregation for Codecov

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -127,10 +127,14 @@ jobs:
 
           echo -e "\n=== Docker Disk Usage ==="
           docker system df -v
+      - name: Generate cross-module coverage report
+        # --no-configure-on-demand is required so every module is configured and visible to
+        # the aggregation task (it reads other modules' outputs without a task dependency).
+        run: ./gradlew jacocoMergedReport --no-configure-on-demand
       - name: Gather coverage files
         run: |
           {
-            echo "BACKEND_FILES=$(find ./build/coverage-reports/ -type f | grep -E '(metadata-models|entity-registry|datahub-graphql-core|metadata-io|metadata-jobs|metadata-utils|metadata-service|medata-dao-impl|metadata-operation|li-utils|metadata-integration|metadata-events|metadata-auth|ingestion-scheduler|notifications|datahub-upgrade)' | xargs | tr ' ' ',')"
+            echo "BACKEND_FILES=$(find ./build/coverage-reports/ -type f | grep -E '(metadata-models|entity-registry|datahub-graphql-core|metadata-io|metadata-jobs|metadata-utils|metadata-service|medata-dao-impl|metadata-operation|li-utils|metadata-integration|metadata-events|metadata-auth|ingestion-scheduler|notifications|datahub-upgrade|jacoco-merged)' | xargs | tr ' ' ',')"
           } >> "$GITHUB_ENV"
       - name: Report test results
         if: (!cancelled())

--- a/build.gradle
+++ b/build.gradle
@@ -904,3 +904,7 @@ tasks.register('resolveAndLockAll') {
     }
   }
 }
+
+// Cross-module aggregated JaCoCo report (recovers coverage of a class produced by tests in
+// another module). See gradle/coverage/java-coverage-aggregation.gradle for details.
+apply from: 'gradle/coverage/java-coverage-aggregation.gradle'

--- a/gradle/coverage/java-coverage-aggregation.gradle
+++ b/gradle/coverage/java-coverage-aggregation.gradle
@@ -1,0 +1,80 @@
+/*
+ * Aggregated (cross-module) JaCoCo coverage report.
+ *
+ * The per-module jacocoTestReport (see java-coverage.gradle) scores a module's own classes
+ * against that module's own test execution data only. When a class in module A is exercised
+ * by tests living in module B, JaCoCo records the hit in B's .exec file, but B's report
+ * discards A's classes (classDirectories is limited to B) and A's report never sees B's
+ * execution data. The cross-module coverage is therefore lost and the class looks untested
+ * in Codecov.
+ *
+ * This task decouples report generation from which tests ran: it scores the classes of every
+ * module that was TESTED in the current invocation against the union of every .exec file
+ * produced in that invocation. Run it once per CI job after the tests; Codecov merges the
+ * per-job reports (covered-in-any-report wins), recovering coverage contributed by tests in
+ * any sibling module that ran in the same job.
+ *
+ * Why only TESTED modules (those that produced a .exec), not every compiled module:
+ *   A module that is merely compiled as a transitive dependency but whose own tests did not
+ *   run in this job would be reported at ~0% (no execution data hits its classes). That is
+ *   wrong and actively harmful when the module's real test job is gated by path filters and
+ *   did not run for this commit (e.g. metadata-io's tests run in metadata-io.yml, are excluded
+ *   from build-and-test, and metadata-io.yml does not fire for a datahub-graphql-core-only PR).
+ *   Such a module would then have NO authoritative report to rescue it and its coverage would
+ *   regress. Restricting classDirectories to modules that actually ran tests here keeps the
+ *   report additive: it can only raise a class's coverage via Codecov's merge, never lower it.
+ *
+ * Note on configure-on-demand: this task reads other projects' outputs but declares no task
+ * dependency on them, so with org.gradle.configureondemand=true Gradle would not configure
+ * those projects and the report would come out empty. Invoke it with
+ * --no-configure-on-demand (see the CI workflows) so every module is configured and visible
+ * to the gradle.projectsEvaluated hook below. It is also meant to run as a SEPARATE gradle
+ * invocation after the tests, so the .exec files already exist when this is configured.
+ */
+// Applied to the root project so the JacocoReport task below gets a configured
+// jacocoClasspath (the JaCoCo tooling classpath); the per-module reports get theirs from
+// java-coverage.gradle. Keep toolVersion in sync with that file.
+apply plugin: 'jacoco'
+
+jacoco {
+  toolVersion = '0.8.12'
+}
+
+tasks.register('jacocoMergedReport', JacocoReport) {
+  group = 'verification'
+  description = 'Aggregates JaCoCo coverage across modules tested in this invocation (cross-module).'
+
+  reports {
+    xml.required = true
+    csv.required = false
+    html.required = false
+    xml.outputLocation = rootProject.layout.buildDirectory.file('coverage-reports/jacoco-merged.xml')
+  }
+
+  // Skip instead of failing when no tests ran in this invocation (e.g. a partial local build).
+  onlyIf { !executionData.empty }
+}
+
+gradle.projectsEvaluated {
+  def execTreeOf = { p -> p.fileTree(p.layout.buildDirectory.dir('jacoco')).include('*.exec') }
+
+  // Generated code dominates report size and has no meaningful coverage. Keep in sync with
+  // java-coverage.gradle.
+  def jacocoCoverageExcludes = ['**/generated/**']
+
+  // Only modules whose tests actually ran in THIS invocation (their .exec exists). See the
+  // header comment for why compiled-but-untested modules must be excluded.
+  def testedProjects = subprojects.findAll { p ->
+    p.pluginManager.hasPlugin('jacoco') &&
+        p.extensions.findByName('sourceSets')?.findByName('main') &&
+        !execTreeOf(p).empty
+  }
+
+  tasks.named('jacocoMergedReport').configure {
+    classDirectories.setFrom(rootProject.files(testedProjects.collect { p ->
+      p.sourceSets.main.output.collect { dir -> p.fileTree(dir: dir, excludes: jacocoCoverageExcludes) }
+    }))
+    sourceDirectories.setFrom(rootProject.files(testedProjects.collect { it.sourceSets.main.allSource.srcDirs }))
+    executionData.setFrom(rootProject.files(testedProjects.collect { execTreeOf(it) }))
+  }
+}

--- a/gradle/coverage/java-coverage.gradle
+++ b/gradle/coverage/java-coverage.gradle
@@ -5,27 +5,54 @@ jacoco {
 }
 
 /*
+Generated code (e.g. io.datahubproject.openapi.generated, com.linkedin.datahub.graphql.generated)
+carries no meaningful coverage signal and dominates report size — the two generated packages alone
+account for ~22MB of the ~29MB backend coverage. Excluding them shrinks both the per-module reports
+and the aggregated report and makes the coverage percentage reflect hand-written code only.
+Keep this list in sync with java-coverage-aggregation.gradle.
+*/
+def jacocoCoverageExcludes = ['**/generated/**']
+
+/*
+Opt out of coverage for a run: ./gradlew :module:test -PskipCoverage
+Disables the JaCoCo agent (so tests run without instrumentation overhead) and skips report
+generation entirely. Coverage is on by default so CI is unaffected.
+*/
+def coverageDisabled = project.hasProperty('skipCoverage')
+
+/*
 These need to run after evaluation since jacoco plugin alters the test task based on the included test
 lib dependencies defined in each subproject (junit or testNG)
 */
 afterEvaluate {
-  test {
-    finalizedBy jacocoTestReport
-  }
-
-  jacocoTestReport {
-    dependsOn test
-    reports {
-      xml {
-        required = true
-        /*
-        Tools that aggregate and analyse coverage tools search for the coverage result files. Keeping them under one
-        folder will minimize the time spent searching through the full source tree.
-        */
-        outputLocation = rootProject.layout.buildDirectory.file("coverage-reports/${rootProject.relativePath(project.projectDir)}/jacoco-${project.name}.xml")
+  if (coverageDisabled) {
+    tasks.withType(Test).configureEach {
+      jacoco {
+        enabled = false
       }
-      csv.required = false
-      html.required = false
+    }
+  } else {
+    test {
+      finalizedBy jacocoTestReport
+    }
+
+    jacocoTestReport {
+      dependsOn test
+      classDirectories.setFrom(files(sourceSets.main.output.collect { dir ->
+        fileTree(dir: dir, excludes: jacocoCoverageExcludes)
+      }))
+      reports {
+        xml {
+          required = true
+          /*
+          Tools that aggregate and analyse coverage tools search for the coverage result files. Keeping them under one
+          folder will minimize the time spent searching through the full source tree.
+          */
+          outputLocation = rootProject.layout.buildDirectory.file("coverage-reports/${rootProject.relativePath(project.projectDir)}/jacoco-${project.name}.xml")
+        }
+        csv.required = false
+        html.required = false
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- **Fix cross-module coverage loss**: per-module `jacocoTestReport` limits `classDirectories` to the module's own classes and `executionData` to its own `.exec`. When a class in module A is tested by module B's tests, that coverage is discarded by both reports and the class appears 0% covered in Codecov.
- **Add `jacocoMergedReport`** (new `gradle/coverage/java-coverage-aggregation.gradle`): scores every module that produced a `.exec` in the current invocation against the union of all execution data. Only tested modules are included — modules that didn't run tests are excluded to avoid false ~0% for path-gated CI jobs.
- **Exclude generated code** (`**/generated/**`) from both per-module and merged reports — two generated packages account for ~22 MB of ~29 MB backend coverage with no hand-written code.
- **Add `-PskipCoverage`** Gradle flag to disable JaCoCo instrumentation for fast local test runs.
- **Wire merged report into `build-and-test.yml`**: run `jacocoMergedReport` after tests and include `jacoco-merged.xml` in the Codecov upload.

## ⚠️ Review notes

This implementation is **AI-assisted and not fully production-tested**. Please review carefully before merging.

### Block requiring attention in `build-and-test.yml`

The "Gather coverage files" step was extended to include `jacoco-merged` in the grep pattern:

```yaml
- name: Gather coverage files
  run: |
    {
      # Before (only per-module reports):
      echo "BACKEND_FILES=$(find ./build/coverage-reports/ -type f | grep -E '(metadata-models|...|datahub-upgrade)' | xargs | tr ' ' ',')"

      # After (adds jacoco-merged.xml):
      echo "BACKEND_FILES=$(find ./build/coverage-reports/ -type f | grep -E '(metadata-models|...|datahub-upgrade|jacoco-merged)' | xargs | tr ' ' ',')"
    } >> "$GITHUB_ENV"
```

This needs to be validated that:
1. `jacocoMergedReport` runs before this step and outputs to `build/coverage-reports/jacoco-merged.xml`
2. The grep pattern correctly picks up the merged file alongside per-module files
3. Codecov handles the combined file list without hitting size or count limits

### `--no-configure-on-demand` requirement

The aggregation task is invoked with `--no-configure-on-demand` because `gradle.properties` sets `org.gradle.configureondemand=true`. Without this flag, subprojects are not configured and `gradle.projectsEvaluated` sees an empty project list. This is documented in the task's header comment.

## Test plan

- [ ] Run `./gradlew :metadata-service:auth-impl:test jacocoMergedReport --no-configure-on-demand` and verify `build/coverage-reports/jacoco-merged.xml` is generated
- [ ] Verify `jacoco-merged.xml` includes classes from modules other than the one whose tests ran
- [ ] Run with `-PskipCoverage` and verify no `.exec` files are produced and `jacocoMergedReport` is skipped (`onlyIf` guard)
- [ ] Trigger `build-and-test` CI and verify Codecov receives the merged report alongside per-module reports
- [ ] Confirm coverage percentages in Codecov increase (or stay the same) — never decrease — relative to the pre-change baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdaSKyWDrRpujyQGGFx8Mi)_